### PR TITLE
feat: tornar rotas de visualização públicas conforme Diretriz 5.1.1 iOS

### DIFF
--- a/src/modules/establishments/controllers/establishment-types.controller.ts
+++ b/src/modules/establishments/controllers/establishment-types.controller.ts
@@ -1,7 +1,5 @@
-import { Controller, Get, UseGuards } from "@nestjs/common"
-import { ApiBearerAuth, ApiResponse, ApiTags } from "@nestjs/swagger"
-
-import { AuthGuard } from "@/auth/infrastructure/auth.guard"
+import { Controller, Get } from "@nestjs/common"
+import { ApiResponse, ApiTags } from "@nestjs/swagger"
 
 import { EstablishmentTypeResponse } from "../application/dto/establishiment-type/get-establishment-types.response"
 import { EstablishmentTypesUseCase } from "../application/use-cases/establishiment-type/get-establishiment-types.use-case"
@@ -13,14 +11,11 @@ export class EstablishmentTypesController {
         private readonly getEstablishmentTypes: EstablishmentTypesUseCase
     ) {}
 
-    @ApiBearerAuth()
     @ApiResponse({
         status: 200,
         type: EstablishmentTypeResponse,
         isArray: true
     })
-    @ApiResponse({ status: 401, description: "Acesso não autorizado" })
-    @UseGuards(AuthGuard)
     @Get()
     async getAllActiveTypes() {
         return await this.getEstablishmentTypes.execute()

--- a/src/modules/products/controllers/products.controller.ts
+++ b/src/modules/products/controllers/products.controller.ts
@@ -27,8 +27,6 @@ import { UpdateProductUseCase } from "../application/use-cases/update-product.us
 
 @Controller("api/products")
 @ApiTags("Returns all categories and products linked to an establishment.")
-@ApiBearerAuth()
-@UseGuards(AuthGuard)
 export class ProductsController {
     constructor(
         private readonly createProduct: CreateProductUseCase,
@@ -42,7 +40,6 @@ export class ProductsController {
         type: CategoryProductsResponseDto,
         isArray: true
     })
-    @ApiResponse({ status: 401, description: "Acesso não autorizado" })
     @ApiResponse({ status: 404, description: "Id não encontrado" })
     @Get("establishment/:id")
     async getProductsByEstablishment(@Param("id") establishmentId: string) {
@@ -51,6 +48,8 @@ export class ProductsController {
         )
     }
 
+    @ApiBearerAuth()
+    @UseGuards(AuthGuard)
     @ApiResponse({
         status: 200,
         type: CreateProductDto,
@@ -66,6 +65,8 @@ export class ProductsController {
         return await this.createProduct.execute(user.sub, product)
     }
 
+    @ApiBearerAuth()
+    @UseGuards(AuthGuard)
     @ApiResponse({
         status: 200,
         type: CreateProductDto,
@@ -85,6 +86,11 @@ export class ProductsController {
         return this.updateProduct.execute(id, user.sub, dto)
     }
 
+    @ApiBearerAuth()
+    @UseGuards(AuthGuard)
+    @ApiResponse({ status: 200, description: "Produto removido com sucesso" })
+    @ApiResponse({ status: 401, description: "Acesso não autorizado" })
+    @ApiResponse({ status: 404, description: "Produto não encontrado" })
     @Delete(":id")
     async remove(
         @Param("id") id: string,


### PR DESCRIPTION
- Remover autenticação de GET products/establishment/:id
- Remover autenticação de GET establishment/types
- Manter rotas de criação/edição/deleção protegidas