### PR TITLE
feat: adiciona módulo admin para gestão de estabelecimentos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ AWS_REGION=example
 AWS_ACCESS_KEY_ID=example
 AWS_SECRET_ACCESS_KEY=example+v8zq6M
 AWS_S3_BUCKET=example
+
+ADMIN_API_KEY=example

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common"
 
 import { DatabaseModule } from "./infra/database/database.module"
 
+import { AdminModule } from "./modules/admin/admin.module"
 import { EstablishmentModule } from "./modules/establishments/establishment.module"
 import { SigninModule } from "./modules/login/signin.module"
 import { OriginModule } from "./modules/origin/origin.module"
@@ -14,6 +15,7 @@ import { ZipCodeModule } from "./modules/zip-code/zip-code.module"
 @Module({
     imports: [
         DatabaseModule,
+        AdminModule,
         EstablishmentModule,
         OriginModule,
         ProductsModule,

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,0 +1,33 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+
+import { EstablishmentTypeLinks } from "@/modules/establishments/domain/entities/establishment-type-links.entity"
+import { EstablishmentTypes } from "@/modules/establishments/domain/entities/establishment-types.entity"
+import { Establishment } from "@/modules/establishments/domain/entities/establishment.entity"
+import { UploadsModule } from "@/modules/uploads/uploads.module"
+
+import { ListEstablishmentsAdminUseCase } from "./application/use-cases/list-establishments-admin.use-case"
+import { UpdateEstablishmentAdminUseCase } from "./application/use-cases/update-establishment-admin.use-case"
+import { UpdateStatusAdminUseCase } from "./application/use-cases/update-status-admin.use-case"
+import { UploadLogoAdminUseCase } from "./application/use-cases/upload-logo-admin.use-case"
+
+import { AdminController } from "./controllers/admin.controller"
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([
+            Establishment,
+            EstablishmentTypeLinks,
+            EstablishmentTypes
+        ]),
+        UploadsModule
+    ],
+    controllers: [AdminController],
+    providers: [
+        ListEstablishmentsAdminUseCase,
+        UpdateEstablishmentAdminUseCase,
+        UpdateStatusAdminUseCase,
+        UploadLogoAdminUseCase
+    ]
+})
+export class AdminModule {}

--- a/src/modules/admin/application/dto/update-establishment-admin.dto.ts
+++ b/src/modules/admin/application/dto/update-establishment-admin.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { Type } from "class-transformer"
+import {
+    IsArray,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    ValidateNested
+} from "class-validator"
+
+import { AddressDto } from "@/modules/shared/dto/address.dto"
+
+export class UpdateEstablishmentAdminDto {
+    @ApiProperty({ example: "Supermercado Economize Mais", required: false })
+    @IsOptional()
+    @IsString()
+    companyName?: string
+
+    @ApiProperty({ example: "Economize Mais", required: false })
+    @IsOptional()
+    @IsString()
+    tradeName?: string
+
+    @ApiProperty({ example: "(35)99942-1613", required: false })
+    @IsOptional()
+    @IsString()
+    @MaxLength(20)
+    phone?: string
+
+    @ApiProperty({
+        example: "https://s3.amazonaws.com/logos/logo.png",
+        required: false
+    })
+    @IsOptional()
+    @IsString()
+    logoUrl?: string
+
+    @ApiProperty({
+        type: String,
+        required: false,
+        description: "ID do tipo de estabelecimento"
+    })
+    @IsOptional()
+    @IsUUID(4)
+    typeId?: string
+
+    @ApiProperty({ type: [AddressDto], required: false })
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => AddressDto)
+    addresses?: AddressDto[]
+}

--- a/src/modules/admin/application/dto/update-status.dto.ts
+++ b/src/modules/admin/application/dto/update-status.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { IsBoolean } from "class-validator"
+
+export class UpdateStatusDto {
+    @ApiProperty({ example: true })
+    @IsBoolean()
+    isActive: boolean
+}

--- a/src/modules/admin/application/use-cases/list-establishments-admin.use-case.ts
+++ b/src/modules/admin/application/use-cases/list-establishments-admin.use-case.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository } from "typeorm"
+
+import { Establishment } from "@/modules/establishments/domain/entities/establishment.entity"
+
+@Injectable()
+export class ListEstablishmentsAdminUseCase {
+    constructor(
+        @InjectRepository(Establishment)
+        private readonly repo: Repository<Establishment>
+    ) {}
+
+    async execute() {
+        return this.repo.find({
+            relations: ["addresses", "typeLinks", "typeLinks.type"],
+            order: { createdAt: "DESC" }
+        })
+    }
+}

--- a/src/modules/admin/application/use-cases/update-establishment-admin.use-case.ts
+++ b/src/modules/admin/application/use-cases/update-establishment-admin.use-case.ts
@@ -1,0 +1,53 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository } from "typeorm"
+
+import { EstablishmentTypeLinks } from "@/modules/establishments/domain/entities/establishment-type-links.entity"
+import { Establishment } from "@/modules/establishments/domain/entities/establishment.entity"
+
+import { UpdateEstablishmentAdminDto } from "../dto/update-establishment-admin.dto"
+
+@Injectable()
+export class UpdateEstablishmentAdminUseCase {
+    constructor(
+        @InjectRepository(Establishment)
+        private readonly repo: Repository<Establishment>,
+        @InjectRepository(EstablishmentTypeLinks)
+        private readonly typeLinksRepo: Repository<EstablishmentTypeLinks>
+    ) {}
+
+    async execute(id: string, dto: UpdateEstablishmentAdminDto) {
+        const establishment = await this.repo.findOne({ where: { id } })
+
+        if (!establishment) {
+            throw new NotFoundException(`Estabelecimento ${id} não encontrado`)
+        }
+
+        if (dto.companyName !== undefined)
+            establishment.companyName = dto.companyName
+        if (dto.tradeName !== undefined) establishment.tradeName = dto.tradeName
+        if (dto.phone !== undefined) establishment.phone = dto.phone
+        if (dto.logoUrl !== undefined) establishment.logoUrl = dto.logoUrl
+
+        await this.repo.save(establishment)
+
+        if (dto.typeId !== undefined) {
+            await this.typeLinksRepo.delete({ establishment_id: id })
+
+            if (dto.typeId) {
+                await this.typeLinksRepo.save(
+                    this.typeLinksRepo.create({
+                        establishment_id: id,
+                        type_id: dto.typeId,
+                        createdAt: new Date()
+                    })
+                )
+            }
+        }
+
+        return this.repo.findOne({
+            where: { id },
+            relations: ["addresses", "typeLinks", "typeLinks.type"]
+        })
+    }
+}

--- a/src/modules/admin/application/use-cases/update-status-admin.use-case.ts
+++ b/src/modules/admin/application/use-cases/update-status-admin.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository } from "typeorm"
+
+import { Establishment } from "@/modules/establishments/domain/entities/establishment.entity"
+
+@Injectable()
+export class UpdateStatusAdminUseCase {
+    constructor(
+        @InjectRepository(Establishment)
+        private readonly repo: Repository<Establishment>
+    ) {}
+
+    async execute(id: string, isActive: boolean) {
+        const establishment = await this.repo.findOne({ where: { id } })
+
+        if (!establishment) {
+            throw new NotFoundException(`Estabelecimento ${id} não encontrado`)
+        }
+
+        establishment.isActive = isActive
+        await this.repo.save(establishment)
+
+        return { id, isActive }
+    }
+}

--- a/src/modules/admin/application/use-cases/upload-logo-admin.use-case.ts
+++ b/src/modules/admin/application/use-cases/upload-logo-admin.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository } from "typeorm"
+
+import { Establishment } from "@/modules/establishments/domain/entities/establishment.entity"
+import { S3UploadService } from "@/modules/uploads/infrastructure/services/s3-upload.service"
+
+@Injectable()
+export class UploadLogoAdminUseCase {
+    constructor(
+        @InjectRepository(Establishment)
+        private readonly repo: Repository<Establishment>,
+        private readonly s3: S3UploadService
+    ) {}
+
+    async execute(
+        establishmentId: string,
+        file: Express.Multer.File
+    ): Promise<{ url: string }> {
+        const establishment = await this.repo.findOne({
+            where: { id: establishmentId }
+        })
+
+        if (!establishment) {
+            throw new NotFoundException(
+                `Estabelecimento ${establishmentId} não encontrado`
+            )
+        }
+
+        const url = await this.s3.uploadFile(file, establishmentId, "logo")
+
+        establishment.logoUrl = url
+        await this.repo.save(establishment)
+
+        return { url }
+    }
+}

--- a/src/modules/admin/controllers/admin.controller.ts
+++ b/src/modules/admin/controllers/admin.controller.ts
@@ -1,0 +1,96 @@
+import {
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    Patch,
+    Post,
+    UploadedFile,
+    UseGuards,
+    UseInterceptors
+} from "@nestjs/common"
+import { FileInterceptor } from "@nestjs/platform-express"
+import {
+    ApiBody,
+    ApiConsumes,
+    ApiResponse,
+    ApiSecurity,
+    ApiTags
+} from "@nestjs/swagger"
+import { UpdateEstablishmentAdminDto } from "../application/dto/update-establishment-admin.dto"
+import { UpdateStatusDto } from "../application/dto/update-status.dto"
+import { ListEstablishmentsAdminUseCase } from "../application/use-cases/list-establishments-admin.use-case"
+import { UpdateEstablishmentAdminUseCase } from "../application/use-cases/update-establishment-admin.use-case"
+import { UpdateStatusAdminUseCase } from "../application/use-cases/update-status-admin.use-case"
+import { UploadLogoAdminUseCase } from "../application/use-cases/upload-logo-admin.use-case"
+
+import { AdminGuard } from "../infrastructure/admin.guard"
+
+@Controller("/api/admin")
+@ApiTags("Admin — gestão de estabelecimentos")
+@ApiSecurity("x-admin-key")
+@UseGuards(AdminGuard)
+export class AdminController {
+    constructor(
+        private readonly listUseCase: ListEstablishmentsAdminUseCase,
+        private readonly updateUseCase: UpdateEstablishmentAdminUseCase,
+        private readonly statusUseCase: UpdateStatusAdminUseCase,
+        private readonly uploadLogoUseCase: UploadLogoAdminUseCase
+    ) {}
+
+    @ApiResponse({
+        status: 201,
+        description: "Faz upload da logo, salva no S3 com o ID real e atualiza o banco"
+    })
+    @ApiConsumes("multipart/form-data")
+    @ApiBody({
+        schema: {
+            type: "object",
+            properties: { file: { type: "string", format: "binary" } },
+            required: ["file"]
+        }
+    })
+    @Post("establishments/:id/logo")
+    @UseInterceptors(FileInterceptor("file"))
+    async uploadLogo(
+        @Param("id") id: string,
+        @UploadedFile() file: Express.Multer.File
+    ) {
+        return this.uploadLogoUseCase.execute(id, file)
+    }
+
+    @ApiResponse({
+        status: 200,
+        description: "Lista todos os estabelecimentos"
+    })
+    @Get("establishments")
+    async findAll() {
+        return this.listUseCase.execute()
+    }
+
+    @ApiResponse({
+        status: 200,
+        description: "Atualiza dados do estabelecimento"
+    })
+    @ApiResponse({ status: 404, description: "Não encontrado" })
+    @Patch("establishments/:id")
+    async update(
+        @Param("id") id: string,
+        @Body() dto: UpdateEstablishmentAdminDto
+    ) {
+        return this.updateUseCase.execute(id, dto)
+    }
+
+    @ApiResponse({
+        status: 200,
+        description: "Ativa ou desativa o estabelecimento"
+    })
+    @ApiResponse({ status: 404, description: "Não encontrado" })
+    @HttpCode(HttpStatus.OK)
+    @Patch("establishments/:id/status")
+    async updateStatus(@Param("id") id: string, @Body() dto: UpdateStatusDto) {
+        return this.statusUseCase.execute(id, dto.isActive)
+    }
+}

--- a/src/modules/admin/infrastructure/admin.guard.ts
+++ b/src/modules/admin/infrastructure/admin.guard.ts
@@ -1,0 +1,20 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    Injectable,
+    UnauthorizedException
+} from "@nestjs/common"
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+    canActivate(context: ExecutionContext): boolean {
+        const request = context.switchToHttp().getRequest()
+        const key = request.headers["x-admin-key"]
+
+        if (!key || key !== process.env.ADMIN_API_KEY) {
+            throw new UnauthorizedException("Chave de admin inválida")
+        }
+
+        return true
+    }
+}

--- a/src/modules/establishments/application/dto/create-establishment.dto.ts
+++ b/src/modules/establishments/application/dto/create-establishment.dto.ts
@@ -7,6 +7,7 @@ import {
     IsNotEmpty,
     IsOptional,
     IsString,
+    IsUUID,
     Matches,
     MaxLength,
     ValidateNested
@@ -56,6 +57,16 @@ export class CreateEstablishmentDto {
     @IsOptional()
     @IsString()
     logoUrl?: string
+
+    @ApiProperty({
+        type: [String],
+        required: false,
+        description: "IDs dos tipos de estabelecimento"
+    })
+    @IsOptional()
+    @IsArray()
+    @IsUUID(4, { each: true })
+    typeIds?: string[]
 
     @ApiProperty({ type: OmitType(AddressDto, ["id"] as const), isArray: true })
     @IsOptional()

--- a/src/modules/establishments/application/dto/establishment-response.dto.ts
+++ b/src/modules/establishments/application/dto/establishment-response.dto.ts
@@ -29,6 +29,9 @@ export class EstablishmentResponseDto {
     @ApiProperty({ example: "https://example.com/logo.png", required: false })
     logoUrl?: string
 
+    @ApiProperty({ example: true })
+    isActive: boolean
+
     @ApiProperty({ example: "eyJhbGciOiJIUzI1NiIsInR5cCI6..." })
     accessToken?: string
 

--- a/src/modules/establishments/application/presenter/establishment.presenter.ts
+++ b/src/modules/establishments/application/presenter/establishment.presenter.ts
@@ -24,6 +24,7 @@ export const establishmentToResponse = (
     dto.cnpj = establishment.cnpj
     dto.phone = establishment.phone
     dto.logoUrl = establishment.logoUrl
+    dto.isActive = establishment.isActive
     dto.addresses = plainToInstance(AddressDto, establishment.addresses, {
         excludeExtraneousValues: true
     })

--- a/src/modules/establishments/application/use-cases/create-establishment.use-case.ts
+++ b/src/modules/establishments/application/use-cases/create-establishment.use-case.ts
@@ -1,10 +1,13 @@
 import { ConflictException, Inject, Injectable } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository } from "typeorm"
 
 import {
     HASH_SERVICE,
     IHashService
 } from "@/common/hash/interfaces/hash-service.interface"
 
+import { EstablishmentTypeLinks } from "../../domain/entities/establishment-type-links.entity"
 import {
     ESTABLISHMENT_REPOSITORY,
     IEstablishmentRepository
@@ -20,7 +23,9 @@ export class CreateServiceUseCase {
         @Inject(HASH_SERVICE)
         private readonly hashProvider: IHashService,
         @Inject(ESTABLISHMENT_REPOSITORY)
-        private readonly repo: IEstablishmentRepository
+        private readonly repo: IEstablishmentRepository,
+        @InjectRepository(EstablishmentTypeLinks)
+        private readonly typeLinksRepo: Repository<EstablishmentTypeLinks>
     ) {}
 
     async execute(data: CreateEstablishmentDto) {
@@ -34,13 +39,22 @@ export class CreateServiceUseCase {
 
         const hashPassoword = await this.hashProvider.hash(data.password)
 
-        const entity = {
-            ...data,
-            password: hashPassoword
-        }
-        const establishments = await this.repo.save(entity)
+        const { typeIds, ...rest } = data
+        const entity = { ...rest, password: hashPassoword }
+        const establishment = await this.repo.save(entity)
 
-        return establishmentToResponse(establishments, {
+        if (typeIds && typeIds.length > 0) {
+            const links = typeIds.map((typeId) =>
+                this.typeLinksRepo.create({
+                    establishment_id: establishment.id,
+                    type_id: typeId,
+                    createdAt: new Date()
+                })
+            )
+            await this.typeLinksRepo.save(links)
+        }
+
+        return establishmentToResponse(establishment, {
             usage: false,
             privacy: false
         })


### PR DESCRIPTION
- AdminGuard autenticando via header x-admin-key
- Endpoints GET /api/admin/establishments, PATCH /:id, PATCH /:id/status
- POST /api/admin/establishments/:id/logo — faz upload no S3 com o ID real do estabelecimento e já atualiza logoUrl no banco
- Suporte a typeIds na criação de estabelecimento (vínculo com categoria)
- Campo isActive exposto no DTO de resposta